### PR TITLE
prevent dependabot major upgrade of got

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     open-pull-requests-limit: 10
     assignees:
       - "kazkansouh"
+    ignore:
+      # version 11 of got is the last to support commonjs, so prevent upgrading to version 12+
+      - dependency-name: "got"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
GOT version 11 is last to support CommonJS so prevent upgrade of major version.

See readme @ https://github.com/sindresorhus/got