### PR TITLE
maint: prevent dependabot bump asn1-ts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,10 @@ updates:
     ignore:
       # version 11 of got is the last to support commonjs, so prevent upgrading to version 12+
       - dependency-name: got
-        update-types: ["version-update:semver-major"]
+        versions: [">=12.0.0"]
+      # version 8 of asn1-ts is the last to support commonjs, so prevent upgrading to version 9+
+      - dependency-name: asn1-ts
+        versions: [">=9.0.0"]
     groups:
       typescript-eslint:
         patterns: ["@typescript-eslint/*"]


### PR DESCRIPTION
asn1-ts v9+ no longer support common js modules, so ignoring in dependabot