### PR TITLE
feat: dynamic http headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,37 @@ If persistence of the local cache is required between program runs then the
 class should be instantiated as follows:
 
 ```typescript
-const keyStore = BoxedKeyStore.new(boxedIpAddress, localCacheFile)
+const keyStore = await BoxedKeyStore.new(boxedIpAddress, localCacheFile)
 ```
 
-If the `localCacheFile` is omitted, a temporary file is crated in the system temp
+If the `localCacheFile` is omitted, a temporary file is created in the system temp
 folder.
+
+#### Using Headers with BoxedKeyStore
+
+The `BoxedKeyStore` can be configured with custom headers for SMKI requests:
+
+```typescript
+import { BoxedKeyStore, KeyUsage } from '@smartdcc/dccboxed-keystore'
+
+// Headers can be static values, sync functions, or async functions
+const headers = {
+  'X-Authentication': 'Bearer token123',
+  'X-Timestamp': () => Date.now().toString(),
+  'X-Dynamic-Token': async () => await fetchToken()
+}
+
+const keyStore = await BoxedKeyStore.new('1.2.3.4', undefined, undefined, headers)
+
+// Headers will be automatically used for any SMKI queries
+const result = await keyStore.query({
+  eui: '00-db-12-34-56-78-90-a4',
+  keyUsage: KeyUsage.keyAgreement,
+  lookup: 'certificate'
+})
+
+await keyStore.cleanup()
+```
 
 ### Advanced Usage
 

--- a/src/boxedKeyStore.ts
+++ b/src/boxedKeyStore.ts
@@ -21,7 +21,6 @@ import { KeyObject, X509Certificate } from 'node:crypto'
 import { rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { tmpNameSync } from 'tmp'
-import { Headers } from 'got'
 import {
   EUI,
   KeyUsage,
@@ -31,6 +30,7 @@ import {
 import {
   CertificateStatus,
   CertificateUsage,
+  Headers,
   query,
   search,
 } from './certificateSearch'

--- a/test/certificateSearch.test.ts
+++ b/test/certificateSearch.test.ts
@@ -1123,6 +1123,89 @@ describe('search', () => {
   })
 })
 
+describe('resolveHeaders', () => {
+  test('defined', () => {
+    expect(cs.resolveHeaders).toBeDefined()
+  })
+
+  test('empty headers', async () => {
+    await expect(cs.resolveHeaders()).resolves.toEqual({})
+  })
+
+  test('string values', async () => {
+    const headers = {
+      'content-type': 'application/json',
+      'authorization': 'Bearer token123'
+    }
+    await expect(cs.resolveHeaders(headers)).resolves.toEqual({
+      'content-type': 'application/json',
+      'authorization': 'Bearer token123'
+    })
+  })
+
+  test('sync function values', async () => {
+    const headers = {
+      'x-timestamp': () => '2023-01-01',
+      'x-random': () => 'abc123'
+    }
+    await expect(cs.resolveHeaders(headers)).resolves.toEqual({
+      'x-timestamp': '2023-01-01',
+      'x-random': 'abc123'
+    })
+  })
+
+  test('async function values', async () => {
+    const headers = {
+      'x-async': async () => 'async-value',
+      'x-promise': () => Promise.resolve('promise-value')
+    }
+    await expect(cs.resolveHeaders(headers)).resolves.toEqual({
+      'x-async': 'async-value',
+      'x-promise': 'promise-value'
+    })
+  })
+
+  test('mixed value types', async () => {
+    const headers = {
+      'static': 'static-value',
+      'sync-func': () => 'sync-value',
+      'async-func': async () => 'async-value'
+    }
+    await expect(cs.resolveHeaders(headers)).resolves.toEqual({
+      'static': 'static-value',
+      'sync-func': 'sync-value',
+      'async-func': 'async-value'
+    })
+  })
+
+  test('merge with existing gotHeaders', async () => {
+    const headers = {
+      'x-custom': 'custom-value'
+    }
+    const gotHeaders = {
+      'content-type': 'application/xml',
+      'user-agent': 'test-agent'
+    }
+    await expect(cs.resolveHeaders(headers, gotHeaders)).resolves.toEqual({
+      'content-type': 'application/xml',
+      'user-agent': 'test-agent',
+      'x-custom': 'custom-value'
+    })
+  })
+
+  test('override existing gotHeaders', async () => {
+    const headers = {
+      'content-type': () => 'application/json'
+    }
+    const gotHeaders = {
+      'content-type': 'application/xml'
+    }
+    await expect(cs.resolveHeaders(headers, gotHeaders)).resolves.toEqual({
+      'content-type': 'application/json'
+    })
+  })
+})
+
 describe('parseUrl', () => {
   test('defined', () => {
     expect(cs.parseUrl).toBeDefined()


### PR DESCRIPTION
Replace fixed `string` values for header value with a function resolver to allow values to change between requests without re-initialising the key store with new header values.