### PR TITLE
fix: pass headers to query call within search

### DIFF
--- a/src/certificateSearch.ts
+++ b/src/certificateSearch.ts
@@ -241,7 +241,7 @@ export async function search(
   }
 
   const queryResults = await Promise.all(
-    serials.map((serial) => query(serial, boxedAddress)),
+    serials.map((serial) => query(serial, boxedAddress, headers)),
   )
   return queryResults.filter((qr) => qr !== null) as QueryResult[]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,4 +26,5 @@ export {
   KeyUsage,
   normaliseEUI,
 } from './certificateMetadata'
+export { resolveHeaders, Headers } from './certificateSearch'
 export { QueryOptions, PushOptions } from './db'


### PR DESCRIPTION
Fix the second API call to SMKI Repo which was missing the passed in headers.